### PR TITLE
Use the subnet default instead of assigning public ip

### DIFF
--- a/workers.tf
+++ b/workers.tf
@@ -112,7 +112,6 @@ data "aws_ami" "eks-worker-ami" {
 
 resource "aws_launch_configuration" "eks-worker-cluster" {
   count                       = "${length(var.nodes)}"
-  associate_public_ip_address = true
   iam_instance_profile        = "${aws_iam_instance_profile.eks-worker.name}"
   image_id                    = "${var.node_ami_id != "" ? var.node_ami_id : data.aws_ami.eks-worker-ami.id}"
   instance_type               = "${lookup(var.nodes[count.index], "instance_type")}"

--- a/workers.tf
+++ b/workers.tf
@@ -111,13 +111,13 @@ data "aws_ami" "eks-worker-ami" {
 }
 
 resource "aws_launch_configuration" "eks-worker-cluster" {
-  count                       = "${length(var.nodes)}"
-  iam_instance_profile        = "${aws_iam_instance_profile.eks-worker.name}"
-  image_id                    = "${var.node_ami_id != "" ? var.node_ami_id : data.aws_ami.eks-worker-ami.id}"
-  instance_type               = "${lookup(var.nodes[count.index], "instance_type")}"
-  name_prefix                 = "eks-cluster"
-  security_groups             = ["${aws_security_group.eks-worker.id}"]
-  user_data_base64            = "${base64encode(local.eks-node-userdata)}"
+  count                = "${length(var.nodes)}"
+  iam_instance_profile = "${aws_iam_instance_profile.eks-worker.name}"
+  image_id             = "${var.node_ami_id != "" ? var.node_ami_id : data.aws_ami.eks-worker-ami.id}"
+  instance_type        = "${lookup(var.nodes[count.index], "instance_type")}"
+  name_prefix          = "eks-cluster"
+  security_groups      = ["${aws_security_group.eks-worker.id}"]
+  user_data_base64     = "${base64encode(local.eks-node-userdata)}"
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
# Pull Request

## Description

Worker instances in private subnet get assigned public IPs. This PR removes the configuration such that the subnet default is used. 

## How Has This Been Tested?

It hasn't. 

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/` directories (look in CI for an example)
- [ ] Provide an updated example that utilizes newly created resources, or for more advanced additions a new example under the examples directory.
- [ ] Example plan output in this PR (in lieu of CI)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Any breaking changes are noted in the description above
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] My code follows the style guidelines of this project
- [ ] Any dependent changes have been merged and published in downstream modules