### PR TITLE
Fix root volume size issue

### DIFF
--- a/workers.tf
+++ b/workers.tf
@@ -126,7 +126,7 @@ resource "aws_launch_configuration" "eks-worker-cluster" {
   }
 
   root_block_device {
-    volume_size = lookup(var.nodes[count.index], "volume_size", 20)
+    volume_size = lookup(var.nodes[count.index], "volume_size", 30)
   }
 }
 


### PR DESCRIPTION
# Pull Request

## Description
The follow error is given when trying to provision a cluster
"Volume of size 20GB is smaller than  snapshot 'snap-07c7be6c5beb29d2d', expect size >= 30GB. Launching EC2 instance failed."

This PR changes the hard coded root volume size for worker instances from 20GB to 30GB

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Example successfully deployed from scratch

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/` directories (look in CI for an example)
- [ ] Provide an updated example that utilizes newly created resources, or for more advanced additions a new example under the examples directory.
- [ ] Example plan output in this PR (in lieu of CI)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Any breaking changes are noted in the description above
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] My code follows the style guidelines of this project
- [ ] Any dependent changes have been merged and published in downstream modules